### PR TITLE
Removal of cmake_cache_args from *.cmake files

### DIFF
--- a/cmake/externals/ITK.cmake
+++ b/cmake/externals/ITK.cmake
@@ -58,7 +58,6 @@ function(ITK_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
             ${ep_project_include_arg}
             -DBUILD_EXAMPLES:BOOL=OFF

--- a/cmake/externals/QtDcm.cmake
+++ b/cmake/externals/QtDcm.cmake
@@ -31,8 +31,7 @@ function(QtDcm_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
-             ${ep_common_cache_args}
+            ${ep_common_cache_args}
             -DBUILD_SHARED_LIBS:BOOL=ON
             -DITK_DIR:FILEPATH=${ITK_DIR}
             -DDCMTK_DIR:FILEPATH=${DCMTK_DIR}

--- a/cmake/externals/RPI.cmake
+++ b/cmake/externals/RPI.cmake
@@ -21,7 +21,6 @@ function(RPI_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
             -DRPI_BUILD_EXAMPLES:BOOL=OFF
             -DBUILD_SHARED_LIBS:BOOL=ON

--- a/cmake/externals/TTK.cmake
+++ b/cmake/externals/TTK.cmake
@@ -26,7 +26,6 @@ function(TTK_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
             -DBUILD_TESTING:BOOL=${ttkp_TESTING}
             -DITK_DIR:FILEPATH=${ITK_DIR}

--- a/cmake/externals/VTK.cmake
+++ b/cmake/externals/VTK.cmake
@@ -45,9 +45,8 @@ function(VTK_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
-             ${additional_vtk_cmakevars}
+            ${additional_vtk_cmakevars}
             -DVTK_WRAP_TCL:BOOL=OFF
             -DBUILD_SHARED_LIBS:BOOL=ON
             -DDESIRED_QT_VERSION:STRING=4

--- a/cmake/externals/dcmtk.cmake
+++ b/cmake/externals/dcmtk.cmake
@@ -41,7 +41,6 @@ function(DCMTK_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
             ${ep_project_include_arg}
             -DBUILD_SHARED_LIBS:BOOL=${shared_libs_option}

--- a/cmake/externals/dtk.cmake
+++ b/cmake/externals/dtk.cmake
@@ -32,11 +32,10 @@ function(dtk_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
-              ${ep_common_cache_args}
-              -DDTK_HAVE_NITE:BOOL=OFF
-              -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
-              ${DISABLE_DTK_COMPOSER}
+            ${ep_common_cache_args}
+            -DDTK_HAVE_NITE:BOOL=OFF
+            -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
+            ${DISABLE_DTK_COMPOSER}
         DEPENDS Qt 
     )
     ExternalForceBuild(dtk)

--- a/cmake/externals/medInria.cmake
+++ b/cmake/externals/medInria.cmake
@@ -24,7 +24,6 @@ function(medInria_project)
         CMAKE_GENERATOR ${gen}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-        CMAKE_CACHE_ARGS
             ${ep_common_cache_args}
             -DDCMTK_DIR:FILEPATH=${DCMTK_DIR}
             -DDCMTK_SOURCE_DIR:FILEPATH=${DCMTK_SOURCE_DIR}


### PR DESCRIPTION
The cmake_cache_args are now given as normal args to cmake. It enables us to configure correctly qtdcm with dcmtk through Visual Studio.
