### PR TITLE
Windows packaging 

### DIFF
--- a/cmake/packaging/Packaging.cmake
+++ b/cmake/packaging/Packaging.cmake
@@ -51,7 +51,7 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${${PROJECT_NAME}_VERSION}-s
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION ${PROJECT_NAME})
 
-set(CPACK_PACKAGE_VENDOR "http://www.inria.fr/")
+set(CPACK_PACKAGE_VENDOR "http://med.inria.fr/")
 set(CPACK_PACKAGE_CONTACT "medInria Team <medinria-userfeedback@inria.fr>")
 
 set(CPACK_PACKAGE_VERSION_MAJOR ${${PROJECT_NAME}_VERSION_MAJOR})
@@ -73,17 +73,99 @@ set(CPACK_SOURCE_TGZ OFF)
 set(CPACK_SOURCE_TZ OFF)
 set(CPACK_SOURCE_ZIP OFF)
 
-foreach(package ${packages}) 
-    if(NOT USE_SYSTEM_${package})
-        ExternalProject_Get_Property(${package} binary_dir)
-        set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${binary_dir};${package};ALL;${package}")
+if (NOT WIN32)
+	foreach(package ${packages}) 
+		if(NOT USE_SYSTEM_${package})
+			ExternalProject_Get_Property(${package} binary_dir)
+			set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${binary_dir};${package};ALL;${package}")
+		endif()
+	endforeach()
+	foreach(dir ${PRIVATE_PLUGINS_DIRS})
+			set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${dir};${dir};ALL;${dir}")
+	endforeach()
+else (NOT WIN32)
+	set(DISTRIB windows)
+	set(CPACK_PACKAGE_TYPE NSIS)
+	set(CPACK_PACKAGING_INSTALL_PREFIX "")
+	set(CPACK_PACKAGE_INSTALL_DIRECTORY "medInria-${${PROJECT_NAME}_VERSION}")
+	set(CPACK_MONOLITHIC_INSTALL 1)
+	
+	if(CMAKE_CL_64)
+		SET(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES64")
+		#  - Text used in the installer GUI
+		SET(CPACK_NSIS_PACKAGE_NAME "medInria (Win64)")
+		#  - Registry key used to store info about the installation
+		SET(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "medInria ${${PROJECT_NAME}_VERSION} (Win64)")
+		SET(MSVC_ARCH x64)
+
+	else(CMAKE_CL_64)
+	    SET(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES")
+		SET(CPACK_NSIS_PACKAGE_NAME "medInria")
+		SET(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "medInria ${${PROJECT_NAME}_VERSION}")
+		SET(MSVC_ARCH x86)
+	endif(CMAKE_CL_64)
+
+	set(CPACK_PACKAGE_FILE_NAME "medInria-${${PROJECT_NAME}_VERSION}-${MSVC_ARCH}")
+
+	set(ICON_PATH "${PROJECT_SOURCE_DIR}/medInria/app/medInria/medInria.ico")
+
+	# The icon to install the application.
+	set(CPACK_NSIS_MUI_ICON ${ICON_PATH})
+
+	# The icon to uninstall the application.
+	set(CPACK_NSIS_MUI_UNIICON ${ICON_PATH})
+
+	# Add a desktop shortcut
+	set(CPACK_CREATE_DESKTOP_LINKS "medInria")
+
+	# The icon in the Add/Remove control panel
+	set(CPACK_NSIS_INSTALLED_ICON_NAME bin\\\\medInria.exe)
+
+	# Add medinria to the PATH
+	set(CPACK_NSIS_MODIFY_PATH "ON")
+
+	# Add shortcut in the Startup menu
+	set(CPACK_PACKAGE_EXECUTABLES "medInria" "medInria")
+
+	# Add a link to the application website in the Startup menu.
+	set(CPACK_NSIS_MENU_LINKS "http://med.inria.fr/" "Homepage for medInria") 
+
+	# Run medInria after installation
+	set(CPACK_NSIS_MUI_FINISHPAGE_RUN "medInria.exe")
+
+	# Delete the Startup menu link after uninstallation
+	set(CPACK_NSIS_DELETE_ICONS_EXTRA "
+		Delete '\$SMPROGRAMS\\\\$MUI_TEMP\\\\*.*'
+	")
+	
+	if (NOT PRIVATE_PLUGINS_DIRS STREQUAL "")
+        message(WARNING "PRIVATE_PLUGINS_DIRS : Be careful to use '/' in your plugin paths and to end each path with '/' to copy the private plugins in the same level as the public plugins. Do no forget to separate each path with ';'")
+        foreach(pluginpath ${PRIVATE_PLUGINS_DIRS}) 
+            install(DIRECTORY ${pluginpath} DESTINATION plugins COMPONENT Runtime FILES_MATCHING PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        endforeach(pluginpath)
+    else(NOT PRIVATE_PLUGINS_DIRS STREQUAL "")
+        message(WARNING "PACKAGING : If you want to add private plugins to your package don't forget to set the PRIVATE_PLUGINS_DIRS variable in the cache.")
     endif()
-endforeach()
 
-foreach(dir ${PRIVATE_PLUGINS_DIRS})
-        set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${dir};${dir};ALL;${dir}")
-endforeach()
-
+	#${CMAKE_CFG_INTDIR}
+    set(APP "\${CMAKE_INSTALL_PREFIX}/bin/medInria.exe")
+	
+    list(APPEND libSearchDirs ${QT_PLUGINS_DIR}/* ${QT_BINARY_DIR} ${ITK_DIR}/bin/Release ${DCMTK_DIR}/bin/Release ${VTK_DIR}/bin/Release ${QTDCM_DIR}/bin/Release ${TTK_DIR}/bin/Release ${dtk_DIR}/bin/Release ${RPI_DIR}/bin/Release ${CMAKE_INSTALL_PREFIX}/bin)
+    set(PLUGINS "\${CMAKE_INSTALL_PREFIX}/plugins/")
+	
+	install(CODE "
+	file(INSTALL ${medInria_DIR}/bin/Release/ DESTINATION \${CMAKE_INSTALL_PREFIX}/bin\)
+	file(INSTALL ${medInria_DIR}/plugins/Release/ DESTINATION \${CMAKE_INSTALL_PREFIX}/plugins\)
+    file(INSTALL ${QT_PLUGINS_DIR}/imageformats DESTINATION \${CMAKE_INSTALL_PREFIX}/bin)
+    file(INSTALL \${PLUGINS} DESTINATION \${CMAKE_INSTALL_PREFIX}/plugins )
+    file(INSTALL ${QT_PLUGINS_DIR}/sqldrivers/qsqlite4.dll DESTINATION \${CMAKE_INSTALL_PREFIX}/bin/sqldrivers\)
+    file(INSTALL ${QT_BINARY_DIR}/QtSvg4.dll DESTINATION \${CMAKE_INSTALL_PREFIX}/bin)
+    file(GLOB_RECURSE PLUGINS
+      \${CMAKE_INSTALL_PREFIX}/plugins/*${CMAKE_SHARED_LIBRARY_SUFFIX}\)
+    include(BundleUtilities)
+    fixup_bundle(\"${APP}\"   \"\${PLUGINS}\"   \"${libSearchDirs}\")
+    " COMPONENT Runtime)
+endif()
 
 if (APPLE)
 	set(CPACK_BINARY_TGZ ON)


### PR DESCRIPTION
This pull request provides the superbuild with a way to create package for medinria on windows systems. (It takes in consideration the private plugin path variable which should contain the path to the .dll of the private plugins)
