### PR TITLE
Changed elseif LINUX to UNIX, LINUX doesn't exist as a cmake variable

### DIFF
--- a/cmake/externals/medInria.cmake
+++ b/cmake/externals/medInria.cmake
@@ -48,7 +48,7 @@ function(medInria_project)
 
 if(APPLE)
     set(medInria_exe_PATH ${binary_dir}/bin/medInria.app/Contents/MacOS/medInria PARENT_SCOPE)
-elseif(LINUX)    
+elseif(UNIX)    
     set(medInria_exe_PATH ${binary_dir}/bin/medInria PARENT_SCOPE)
 endif()
 


### PR DESCRIPTION
There was a change on the medInria.sh.in cmake template, to support the Mac path to medInria, but the change was not tested on Linux, and didn't work. I'm not sure we should let @msermesant merge PR again :stuck_out_tongue_winking_eye: 
