### PR TITLE
Convert the paths given via the PRIVATE_PLUGINS_DIRS parameter to CMake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ option(USE_GITHUB_SSH
   )
 mark_as_advanced(USE_GITHUB_SSH)
 
-set(PRIVATE_PLUGINS_DIRS "" CACHE PATH "Folders containing private plugins")
+set(PRIVATE_PLUGINS_DIRS "" CACHE PATH "Folders containing private plugins, separated by ';'")
 mark_as_advanced(PRIVATE_PLUGINS_DIRS)
 
 ## #############################################################################

--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -67,12 +67,9 @@ set(CPACK_NSIS_DELETE_ICONS_EXTRA "
 
 file(TO_CMAKE_PATH PRIVATE_PLUGINS_DIRS PRIVATE_PLUGINS_DIRS)
 if (NOT PRIVATE_PLUGINS_DIRS STREQUAL "")
-    message(WARNING "PRIVATE_PLUGINS_DIRS : Be careful to use '/' in your plugin paths and to end each path with '/' to copy the private plugins in the same level as the public plugins. Do not forget to separate each path with ';'")
     foreach(pluginpath ${PRIVATE_PLUGINS_DIRS}) 
         install(DIRECTORY ${pluginpath} DESTINATION plugins COMPONENT Runtime FILES_MATCHING PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}")
     endforeach()
-else()
-    message(WARNING "PACKAGING : If you want to add private plugins to your package don't forget to set the PRIVATE_PLUGINS_DIRS variable in the cache.")
 endif()
 
 #${CMAKE_CFG_INTDIR}


### PR DESCRIPTION
Quick fix for windows machines, the paths they received from jenkins contained some anti-slashes that CMake was interpreting as escape commands, thus not packaging private plugins.
