### PR TITLE
USE_GITHUB_SSH and PRIVATE_PLUGINS_DIRS are not mark as advanced anymore...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,9 @@ endif()
 option(USE_GITHUB_SSH 
   "Use by default Git SSH addresses, requires public key set on github" OFF
   )
-mark_as_advanced(USE_GITHUB_SSH)
 
 set(PRIVATE_PLUGINS_DIRS "" CACHE PATH "Folders containing private plugins, separated by ';'")
-mark_as_advanced(PRIVATE_PLUGINS_DIRS)
+
 
 ## #############################################################################
 ## Add Targets


### PR DESCRIPTION
A really small PR, because it is painful to scroll to the bottom of the list of advanced varibales looking for those two ones.
