### PR TITLE
Switch medInria to ITK 4.5

### DIFF
--- a/cmake/externals/projects_modules/ITK.cmake
+++ b/cmake/externals/projects_modules/ITK.cmake
@@ -51,8 +51,8 @@ EP_SetDirectories(${ep}
 
 if (NOT DEFINED ${ep}_SOURCE_DIR)
   set(location
-    URL "http://sourceforge.net/projects/itk/files/itk/4.4/InsightToolkit-4.4.2.tar.gz"
-    URL_MD5 "5fd91d6f72e07f51e1e9b27ff02f020a"
+    URL "http://sourceforge.net/projects/itk/files/itk/4.5/InsightToolkit-4.5.0.tar.gz"
+    URL_MD5 "54ae97f62eea1d6f9deb67232c2115a7"
     )
 endif()
 


### PR DESCRIPTION
This PR is in fact a multiple PR to switch the superproject to ITK 4.5. It's not that I want to follow every ITK release but rather that this official release solves the compilation problems on OSX Mavericks. So it would be cool to have it. The downside is that of course it generated quite a few compilation errors. The following PR make the main superproject work with ITK 4.5:
- medinria: https://github.com/medInria/medInria-public/pull/132
- RPI: https://github.com/Inria-Asclepios/RPI/pull/10
- TTK: a patch is here for it https://gist.github.com/ocommowi/e00aed024ee907b45aae
- QtDCM: https://github.com/medInria/qtdcm/pull/3

And that's it. Of course, it's going to break asclepios and visages plugins. But the real and almost only change to do everywhere is to change ${ITKReview_LIBRARIES} to ITKIOMRC. I'll be working on it for visages plugins
