### PR TITLE
Add ITK patch for Mac, solve bug in superproject

### DIFF
--- a/cmake/externals/configuration_steps/EP_GeneratePatchCommand.cmake
+++ b/cmake/externals/configuration_steps/EP_GeneratePatchCommand.cmake
@@ -9,7 +9,7 @@ function(ep_GeneratePatchCommand ep OutVar)
                         RESULT_VARIABLE   PATCH_OK
                         OUTPUT_QUIET
                         ERROR_QUIET)
-        if (PATCH_OK EQUAL 0)
+        if (PATCH_OK EQUAL 0 OR NOT EXISTS ${CMAKE_SOURCE_DIR}/${ep})
             set(PATCHES_TO_APPLY ${PATCHES_TO_APPLY} ${CMAKE_SOURCE_DIR}/patches/${patch})
         endif()
     endforeach()

--- a/cmake/externals/projects_modules/ITK.cmake
+++ b/cmake/externals/projects_modules/ITK.cmake
@@ -82,7 +82,7 @@ set(cmake_args
 ## Check if patch has to be applied
 ## #############################################################################
 
-ep_GeneratePatchCommand(ITK ITK_PATCH_COMMAND)
+ep_GeneratePatchCommand(ITK ITK_PATCH_COMMAND ITK_Mac_Rpath.patch)
 
 ## #############################################################################
 ## Add external-project

--- a/patches/ITK_Mac_Rpath.patch
+++ b/patches/ITK_Mac_Rpath.patch
@@ -1,0 +1,13 @@
+diff --git a/Modules/ThirdParty/KWSys/src/CMakeLists.txt b/Modules/ThirdParty/KWSys/src/CMakeLists.txt
+index 75b8ccd..5be8387 100644
+--- a/Modules/ThirdParty/KWSys/src/CMakeLists.txt
++++ b/Modules/ThirdParty/KWSys/src/CMakeLists.txt
+@@ -18,7 +18,7 @@ set(KWSYS_INSTALL_DOC_DIR ${ITK_INSTALL_DOC_DIR})
+ set(KWSYS_INSTALL_EXPORT_NAME ${ITKKWSys-targets})
+ set(KWSYS_INSTALL_COMPONENT_NAME_RUNTIME RuntimeLibraries)
+ set(KWSYS_INSTALL_COMPONENT_NAME_DEVELOPMENT Development)
+-set(KWSYS_PROPERTIES_CXX MACOSX_RPATH 1)
++#set(KWSYS_PROPERTIES_CXX MACOSX_RPATH 1)
+ 
+ add_subdirectory(KWSys)
+ itk_module_target(${KWSYS_NAMESPACE} NO_INSTALL)


### PR DESCRIPTION
Two things in there:
- patch ITK 4.6 : it was using rpath variables to localize libraries on MacOS, which was not compatible with dtkDeploy -> mac nightly bundles couldn't load any plugins
- patches didn't get applied if the source folder was not there (this meant you had to compile twice to get the patches applied the very first time you downloaded medinria): this PR contains a tentative correction for that
