### PR TITLE
Switch to ITK 4.8

### DIFF
--- a/cmake/externals/projects_modules/ITK.cmake
+++ b/cmake/externals/projects_modules/ITK.cmake
@@ -49,9 +49,9 @@ EP_SetDirectories(${ep}
 ## Define repository where get the sources
 ## #############################################################################
 
-set(tag "v4.6.0")
+set(tag "v4.8.0")
 if (NOT DEFINED ${ep}_SOURCE_DIR)
-    set(location GIT_REPOSITORY "git://itk.org/ITK.git" GIT_TAG ${tag})
+    set(location GIT_REPOSITORY "${GITHUB_PREFIX}InsightSoftwareConsortium/ITK.git" GIT_TAG ${tag})
 endif()
 
 


### PR DESCRIPTION
Switch medInria to using ITK 4.8.0. This is for staying up-to-date and for the fact that some changes appeared in the transformations API.

Needs to merge the two first to work:
- https://github.com/Inria-Asclepios/TTK-Public/pull/7 
- https://github.com/Inria-Asclepios/RPI/pull/14